### PR TITLE
to check class method existences before use runkit_method_rename

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name" : "lancerhe/phpunit-mock",
+    "name" : "windrainw/phpunit-mock",
     "description" : "PHPUnit extension to Mock PHP internal functions using Runkit.",
     "keywords" : [
         "phpunit",

--- a/src/PHPUnit/Extensions/MockClass.php
+++ b/src/PHPUnit/Extensions/MockClass.php
@@ -60,8 +60,11 @@ class PHPUnit_Extensions_MockClass {
             return $this;
 
         $this->_mock = true;
+
         foreach ($this->_methods as $method) {
-            runkit_method_rename( $this->_class_name, $method, "_origin_" . $method);
+            if(method_exists($this->_class_name, $method)){
+                runkit_method_rename( $this->_class_name, $method, "_origin_" . $method);
+            }
             runkit_method_add   ( $this->_class_name, $method, '', $this->getMockCode($method));
         }
         return $this;
@@ -79,7 +82,9 @@ class PHPUnit_Extensions_MockClass {
         $this->_mock = false;
         foreach ($this->_methods as $method) {
             runkit_method_remove( $this->_class_name, $method);
-            runkit_method_rename( $this->_class_name, "_origin_" . $method, $method);
+            if(method_exists($this->_class_name, "_origin_" . $method)){
+                runkit_method_rename( $this->_class_name, "_origin_" . $method, $method);
+            }
         }
         return $this;
     }


### PR DESCRIPTION
this situation is when we use magical method __call and renew a object to call method, method_exists check will return false. directly use runkit_method_rename method will get a error.
